### PR TITLE
improve time analysis explanation

### DIFF
--- a/problems/string/longest_common_prefix/explanation.md
+++ b/problems/string/longest_common_prefix/explanation.md
@@ -9,7 +9,7 @@ Pick the first word to iterate through and keep taking a substring from the begi
 Let: <br>
 
 - `n` be the size of the input array <br>
-- `m` be the size of one of the strings in the array
+- `m` be the size of the shortest string in the array
 
 Worst cases: <br>
 


### PR DESCRIPTION
in the time complexity analysis "m" should represent the shortest string not just one of the strings in the array. In the worse case the shortest string is equivalent to the length of all the strings when all the words are the same.